### PR TITLE
Feature/304 UI adjust synthesis card

### DIFF
--- a/DriveKitApp/SynthesisCardTest.swift
+++ b/DriveKitApp/SynthesisCardTest.swift
@@ -114,3 +114,33 @@ private struct CustomSynthesisCardInfo: DKSynthesisCardInfo {
         self.text.dkAttributedString().build()
     }
 }
+
+private struct CustomGaugeOnlySynthesisCard: DKSynthesisCard {
+    func getTitle() -> String {
+        "Custom gauge only synthesis card"
+    }
+
+    func getExplanationContent() -> String? {
+        return nil
+    }
+
+    func getGaugeConfiguration() -> DKGaugeConfiguration {
+        return CustomGaugeConfiguration()
+    }
+
+    func getTopSynthesisCardInfo() -> DKSynthesisCardInfo {
+        return CustomSynthesisCardInfo(icon: nil, text: "")
+    }
+
+    func getMiddleSynthesisCardInfo() -> DKSynthesisCardInfo {
+        return CustomSynthesisCardInfo(icon: nil, text: "")
+    }
+
+    func getBottomSynthesisCardInfo() -> DKSynthesisCardInfo {
+        return CustomSynthesisCardInfo(icon: nil, text: "")
+    }
+
+    func getBottomText() -> NSAttributedString? {
+        return nil
+    }
+}

--- a/DriveKitDriverDataUI/Synthesis Card/View/SynthesisCardInfoView.xib
+++ b/DriveKitDriverDataUI/Synthesis Card/View/SynthesisCardInfoView.xib
@@ -4,7 +4,6 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -30,7 +29,6 @@
                             <nil key="highlightedColor"/>
                         </label>
                     </subviews>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
                         <constraint firstAttribute="trailing" secondItem="EiO-MN-3eF" secondAttribute="trailing" id="73D-gp-FsU"/>
                         <constraint firstItem="EiO-MN-3eF" firstAttribute="top" secondItem="OW6-KL-bcP" secondAttribute="top" id="DB1-wg-wbg"/>
@@ -57,9 +55,4 @@
             <point key="canvasLocation" x="140.57971014492756" y="117.85714285714285"/>
         </view>
     </objects>
-    <resources>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-    </resources>
 </document>

--- a/DriveKitDriverDataUI/Synthesis Card/View/SynthesisCardInfoView.xib
+++ b/DriveKitDriverDataUI/Synthesis Card/View/SynthesisCardInfoView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -28,6 +28,8 @@
             </subviews>
             <constraints>
                 <constraint firstAttribute="trailing" secondItem="EiO-MN-3eF" secondAttribute="trailing" id="5YG-Y5-wai"/>
+                <constraint firstAttribute="height" relation="lessThanOrEqual" constant="50" id="8dd-DQ-l8B"/>
+                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="34" id="Cxa-1Z-4eg"/>
                 <constraint firstItem="Hao-8H-Y85" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="Dvb-2F-qa6"/>
                 <constraint firstItem="EiO-MN-3eF" firstAttribute="leading" secondItem="Hao-8H-Y85" secondAttribute="trailing" constant="10" id="Xa3-W5-0VJ"/>
                 <constraint firstItem="Hao-8H-Y85" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="fOf-ek-glt"/>

--- a/DriveKitDriverDataUI/Synthesis Card/View/SynthesisCardInfoView.xib
+++ b/DriveKitDriverDataUI/Synthesis Card/View/SynthesisCardInfoView.xib
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -12,29 +13,41 @@
         <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iN0-l3-epB" customClass="SynthesisCardInfoView" customModule="DriveKitDriverDataUI" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="414" height="40"/>
             <subviews>
-                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Hao-8H-Y85">
-                    <rect key="frame" x="0.0" y="0.0" width="40" height="40"/>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OW6-KL-bcP">
+                    <rect key="frame" x="0.0" y="0.0" width="414" height="40"/>
+                    <subviews>
+                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Hao-8H-Y85">
+                            <rect key="frame" x="0.0" y="0.0" width="40" height="40"/>
+                            <constraints>
+                                <constraint firstAttribute="width" relation="lessThanOrEqual" constant="50" id="TbJ-zA-ERG"/>
+                                <constraint firstAttribute="width" secondItem="Hao-8H-Y85" secondAttribute="height" multiplier="1:1" id="bZf-4D-lFC"/>
+                            </constraints>
+                        </imageView>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EiO-MN-3eF">
+                            <rect key="frame" x="50" y="0.0" width="364" height="40"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
-                        <constraint firstAttribute="width" relation="lessThanOrEqual" constant="50" id="TbJ-zA-ERG"/>
-                        <constraint firstAttribute="width" secondItem="Hao-8H-Y85" secondAttribute="height" multiplier="1:1" id="bZf-4D-lFC"/>
+                        <constraint firstAttribute="trailing" secondItem="EiO-MN-3eF" secondAttribute="trailing" id="73D-gp-FsU"/>
+                        <constraint firstItem="EiO-MN-3eF" firstAttribute="top" secondItem="OW6-KL-bcP" secondAttribute="top" id="DB1-wg-wbg"/>
+                        <constraint firstItem="Hao-8H-Y85" firstAttribute="leading" secondItem="OW6-KL-bcP" secondAttribute="leading" id="ZmL-bc-6s3"/>
+                        <constraint firstAttribute="height" priority="750" constant="40" id="c5p-a1-PbN"/>
+                        <constraint firstAttribute="bottom" secondItem="EiO-MN-3eF" secondAttribute="bottom" id="hNy-aA-WiO"/>
+                        <constraint firstItem="Hao-8H-Y85" firstAttribute="top" secondItem="OW6-KL-bcP" secondAttribute="top" id="n2M-nw-QOG"/>
+                        <constraint firstItem="EiO-MN-3eF" firstAttribute="leading" secondItem="Hao-8H-Y85" secondAttribute="trailing" constant="10" id="rWD-U5-GmB"/>
+                        <constraint firstAttribute="bottom" secondItem="Hao-8H-Y85" secondAttribute="bottom" id="rvs-iC-Ve8"/>
                     </constraints>
-                </imageView>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EiO-MN-3eF">
-                    <rect key="frame" x="50" y="20" width="364" height="0.0"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                    <nil key="textColor"/>
-                    <nil key="highlightedColor"/>
-                </label>
+                </view>
             </subviews>
             <constraints>
-                <constraint firstAttribute="trailing" secondItem="EiO-MN-3eF" secondAttribute="trailing" id="5YG-Y5-wai"/>
-                <constraint firstAttribute="height" relation="lessThanOrEqual" constant="50" id="8dd-DQ-l8B"/>
-                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="34" id="Cxa-1Z-4eg"/>
-                <constraint firstItem="Hao-8H-Y85" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="Dvb-2F-qa6"/>
-                <constraint firstItem="EiO-MN-3eF" firstAttribute="leading" secondItem="Hao-8H-Y85" secondAttribute="trailing" constant="10" id="Xa3-W5-0VJ"/>
-                <constraint firstItem="Hao-8H-Y85" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="fOf-ek-glt"/>
-                <constraint firstAttribute="bottom" secondItem="Hao-8H-Y85" secondAttribute="bottom" id="hpn-m0-COQ"/>
-                <constraint firstItem="EiO-MN-3eF" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="led-u1-IPP"/>
+                <constraint firstItem="OW6-KL-bcP" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="8iP-EZ-Dr5"/>
+                <constraint firstItem="OW6-KL-bcP" firstAttribute="height" relation="lessThanOrEqual" secondItem="iN0-l3-epB" secondAttribute="height" id="P9H-dn-kxx"/>
+                <constraint firstItem="OW6-KL-bcP" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="Vid-4Q-g0X"/>
+                <constraint firstAttribute="trailing" secondItem="OW6-KL-bcP" secondAttribute="trailing" id="eOh-ra-BHT"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
@@ -44,4 +57,9 @@
             <point key="canvasLocation" x="140.57971014492756" y="117.85714285714285"/>
         </view>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/DriveKitDriverDataUI/Synthesis Card/View/SynthesisCardView.swift
+++ b/DriveKitDriverDataUI/Synthesis Card/View/SynthesisCardView.swift
@@ -16,6 +16,9 @@ final class SynthesisCardView: UIView, Nibable {
     @IBOutlet private weak var circularProgressViewContainer: UIView!
     @IBOutlet private weak var cardInfoContainer: UIStackView!
     @IBOutlet private weak var bottomText: UILabel!
+    @IBOutlet private weak var notCenteredConstraint: NSLayoutConstraint!
+    @IBOutlet private weak var centeredConstraint: NSLayoutConstraint!
+
     private weak var topSynthesisCardInfo: SynthesisCardInfoView!
     private weak var middleSynthesisCardInfo: SynthesisCardInfoView!
     private weak var bottomSynthesisCardInfo: SynthesisCardInfoView!
@@ -76,6 +79,15 @@ final class SynthesisCardView: UIView, Nibable {
             }
             if self.bottomSynthesisCardInfo.synthesisCardInfoViewModel?.isEmpty() == true {
                 self.bottomSynthesisCardInfo.isHidden = true
+            }
+            if self.synthesisCardViewModel?.shouldHideCardInfoContainer() == true {
+                self.cardInfoContainer.isHidden = true
+                self.centeredConstraint.isActive = true
+                self.notCenteredConstraint.isActive = false
+            } else {
+                self.cardInfoContainer.isHidden = false
+                self.centeredConstraint.isActive = false
+                self.notCenteredConstraint.isActive = true
             }
         }
     }

--- a/DriveKitDriverDataUI/Synthesis Card/View/SynthesisCardView.swift
+++ b/DriveKitDriverDataUI/Synthesis Card/View/SynthesisCardView.swift
@@ -44,9 +44,13 @@ final class SynthesisCardView: UIView, Nibable {
         let topSynthesisCardInfo = SynthesisCardInfoView.viewFromNib
         let middleSynthesisCardInfo = SynthesisCardInfoView.viewFromNib
         let bottomSynthesisCardInfo = SynthesisCardInfoView.viewFromNib
+        cardInfoContainer.addArrangedSubview(UIView())
         cardInfoContainer.addArrangedSubview(topSynthesisCardInfo)
+        cardInfoContainer.addArrangedSubview(UIView())
         cardInfoContainer.addArrangedSubview(middleSynthesisCardInfo)
+        cardInfoContainer.addArrangedSubview(UIView())
         cardInfoContainer.addArrangedSubview(bottomSynthesisCardInfo)
+        cardInfoContainer.addArrangedSubview(UIView())
         self.topSynthesisCardInfo = topSynthesisCardInfo
         self.middleSynthesisCardInfo = middleSynthesisCardInfo
         self.bottomSynthesisCardInfo = bottomSynthesisCardInfo
@@ -63,6 +67,16 @@ final class SynthesisCardView: UIView, Nibable {
             self.topSynthesisCardInfo.synthesisCardInfoViewModel = tripCardViewModel.getTopSynthesisCardInfoViewModel()
             self.middleSynthesisCardInfo.synthesisCardInfoViewModel = tripCardViewModel.getMiddleSynthesisCardInfoViewModel()
             self.bottomSynthesisCardInfo.synthesisCardInfoViewModel = tripCardViewModel.getBottomSynthesisCardInfoViewModel()
+
+            if self.topSynthesisCardInfo.synthesisCardInfoViewModel?.isEmpty() == true {
+                self.topSynthesisCardInfo.isHidden = true
+            }
+            if self.middleSynthesisCardInfo.synthesisCardInfoViewModel?.isEmpty() == true {
+                self.middleSynthesisCardInfo.isHidden = true
+            }
+            if self.bottomSynthesisCardInfo.synthesisCardInfoViewModel?.isEmpty() == true {
+                self.bottomSynthesisCardInfo.isHidden = true
+            }
         }
     }
 

--- a/DriveKitDriverDataUI/Synthesis Card/View/SynthesisCardView.swift
+++ b/DriveKitDriverDataUI/Synthesis Card/View/SynthesisCardView.swift
@@ -47,13 +47,9 @@ final class SynthesisCardView: UIView, Nibable {
         let topSynthesisCardInfo = SynthesisCardInfoView.viewFromNib
         let middleSynthesisCardInfo = SynthesisCardInfoView.viewFromNib
         let bottomSynthesisCardInfo = SynthesisCardInfoView.viewFromNib
-        cardInfoContainer.addArrangedSubview(UIView())
         cardInfoContainer.addArrangedSubview(topSynthesisCardInfo)
-        cardInfoContainer.addArrangedSubview(UIView())
         cardInfoContainer.addArrangedSubview(middleSynthesisCardInfo)
-        cardInfoContainer.addArrangedSubview(UIView())
         cardInfoContainer.addArrangedSubview(bottomSynthesisCardInfo)
-        cardInfoContainer.addArrangedSubview(UIView())
         self.topSynthesisCardInfo = topSynthesisCardInfo
         self.middleSynthesisCardInfo = middleSynthesisCardInfo
         self.bottomSynthesisCardInfo = bottomSynthesisCardInfo

--- a/DriveKitDriverDataUI/Synthesis Card/View/SynthesisCardView.xib
+++ b/DriveKitDriverDataUI/Synthesis Card/View/SynthesisCardView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -43,10 +43,10 @@
                                     <rect key="frame" x="0.0" y="0.0" width="207" height="134"/>
                                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 </view>
-                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="top" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="DjJ-HT-ZS7">
+                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="DjJ-HT-ZS7">
                                     <rect key="frame" x="227" y="0.0" width="187" height="134"/>
                                     <subviews>
-                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="56p-DK-5pS">
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JNf-hf-73w">
                                             <rect key="frame" x="0.0" y="0.0" width="187" height="134"/>
                                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         </view>

--- a/DriveKitDriverDataUI/Synthesis Card/View/SynthesisCardView.xib
+++ b/DriveKitDriverDataUI/Synthesis Card/View/SynthesisCardView.xib
@@ -63,8 +63,14 @@
                                 <constraint firstItem="zPt-fz-E6m" firstAttribute="leading" secondItem="POK-HP-OZm" secondAttribute="leading" id="X9R-In-aed"/>
                                 <constraint firstAttribute="bottom" secondItem="DjJ-HT-ZS7" secondAttribute="bottom" id="bnW-nX-Ohs"/>
                                 <constraint firstItem="DjJ-HT-ZS7" firstAttribute="top" secondItem="POK-HP-OZm" secondAttribute="top" id="cRK-pu-ImK"/>
+                                <constraint firstItem="zPt-fz-E6m" firstAttribute="centerX" secondItem="POK-HP-OZm" secondAttribute="centerX" id="g4l-if-Eo4"/>
                                 <constraint firstItem="DjJ-HT-ZS7" firstAttribute="leading" secondItem="zPt-fz-E6m" secondAttribute="trailing" constant="20" id="olh-ZI-QVb"/>
                             </constraints>
+                            <variation key="default">
+                                <mask key="constraints">
+                                    <exclude reference="g4l-if-Eo4"/>
+                                </mask>
+                            </variation>
                         </view>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="50C-hP-i9v">
                             <rect key="frame" x="0.0" y="138" width="414" height="32"/>
@@ -95,8 +101,10 @@
             <connections>
                 <outlet property="bottomText" destination="50C-hP-i9v" id="cmg-MS-lIj"/>
                 <outlet property="cardInfoContainer" destination="DjJ-HT-ZS7" id="3jP-Am-Ap0"/>
+                <outlet property="centeredConstraint" destination="g4l-if-Eo4" id="WT9-TV-mAy"/>
                 <outlet property="circularProgressViewContainer" destination="zPt-fz-E6m" id="M3V-xR-hrp"/>
                 <outlet property="explanationButton" destination="FYW-ef-yuT" id="CgT-4R-hf8"/>
+                <outlet property="notCenteredConstraint" destination="X9R-In-aed" id="TdL-Uq-Uh0"/>
                 <outlet property="title" destination="feg-JG-Sr7" id="fCc-ic-CLB"/>
             </connections>
             <point key="canvasLocation" x="44.927536231884062" y="122.54464285714285"/>

--- a/DriveKitDriverDataUI/Synthesis Card/View/SynthesisCardView.xib
+++ b/DriveKitDriverDataUI/Synthesis Card/View/SynthesisCardView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -43,7 +43,7 @@
                                     <rect key="frame" x="0.0" y="0.0" width="207" height="134"/>
                                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 </view>
-                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="DjJ-HT-ZS7">
+                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="top" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="DjJ-HT-ZS7">
                                     <rect key="frame" x="227" y="0.0" width="187" height="134"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="56p-DK-5pS">

--- a/DriveKitDriverDataUI/Synthesis Card/ViewModel/SynthesisCardInfoViewModel.swift
+++ b/DriveKitDriverDataUI/Synthesis Card/ViewModel/SynthesisCardInfoViewModel.swift
@@ -23,4 +23,8 @@ struct SynthesisCardInfoViewModel {
     func getText() -> NSAttributedString {
         self.synthesisCardInfo.getText()
     }
+
+    func isEmpty() -> Bool {
+        return getText().length == 0 && getIcon() == nil
+    }
 }

--- a/DriveKitDriverDataUI/Synthesis Card/ViewModel/SynthesisCardViewModel.swift
+++ b/DriveKitDriverDataUI/Synthesis Card/ViewModel/SynthesisCardViewModel.swift
@@ -48,4 +48,17 @@ struct SynthesisCardViewModel {
     private func getSynthesisCardInfoViewModel(from synthesisCardInfo: DKSynthesisCardInfo) -> SynthesisCardInfoViewModel {
         return SynthesisCardInfoViewModel(synthesisCardInfo: synthesisCardInfo)
     }
+
+    func shouldHideCardInfoContainer() -> Bool {
+        let topViewModel = getTopSynthesisCardInfoViewModel()
+        let middleViewModel = getMiddleSynthesisCardInfoViewModel()
+        let bottomViewModel = getBottomSynthesisCardInfoViewModel()
+        
+        return topViewModel.getIcon() == nil
+        && topViewModel.getText().length == 0
+        && middleViewModel.getIcon() == nil
+        && middleViewModel.getText().length == 0
+        && bottomViewModel.getIcon() == nil
+        && bottomViewModel.getText().length == 0
+    }
 }

--- a/DriveKitDriverDataUI/Synthesis Card/ViewModel/SynthesisCardViewModel.swift
+++ b/DriveKitDriverDataUI/Synthesis Card/ViewModel/SynthesisCardViewModel.swift
@@ -50,15 +50,8 @@ struct SynthesisCardViewModel {
     }
 
     func shouldHideCardInfoContainer() -> Bool {
-        let topViewModel = getTopSynthesisCardInfoViewModel()
-        let middleViewModel = getMiddleSynthesisCardInfoViewModel()
-        let bottomViewModel = getBottomSynthesisCardInfoViewModel()
-        
-        return topViewModel.getIcon() == nil
-        && topViewModel.getText().length == 0
-        && middleViewModel.getIcon() == nil
-        && middleViewModel.getText().length == 0
-        && bottomViewModel.getIcon() == nil
-        && bottomViewModel.getText().length == 0
+        return getTopSynthesisCardInfoViewModel().isEmpty()
+        && getMiddleSynthesisCardInfoViewModel().isEmpty()
+        && getBottomSynthesisCardInfoViewModel().isEmpty()
     }
 }


### PR DESCRIPTION
To test the case when progress view is centered, replace the code between lines 34->43 from **SynthesisCardTest.swift** with the following code 
```
        let customGaugeOnlyCardView = DriverDataSynthesisCardsUI.getSynthesisCardView(CustomGaugeOnlySynthesisCard())
        customGaugeOnlyCardView.translatesAutoresizingMaskIntoConstraints = false
        addShadow(to: customGaugeOnlyCardView)
        viewController.view.addSubview(customGaugeOnlyCardView)
        viewController.view.addConstraints([
            customGaugeOnlyCardView.heightAnchor.constraint(equalToConstant: 190),
            customGaugeOnlyCardView.topAnchor.constraint(equalTo: cardsView.bottomAnchor, constant: margin/*2+190*/),
            customGaugeOnlyCardView.leftAnchor.constraint(equalTo: viewController.view.leftAnchor, constant: margin),
            customGaugeOnlyCardView.rightAnchor.constraint(equalTo: viewController.view.rightAnchor, constant: -margin)
        ])
 
```