### PR TITLE
Feature/reverse geocoder improvements

### DIFF
--- a/DriveKitDriverDataUI/Trip Detail/ViewControllers/MapViewController.swift
+++ b/DriveKitDriverDataUI/Trip Detail/ViewControllers/MapViewController.swift
@@ -12,9 +12,7 @@ import DriveKitDBTripAccessModule
 import MapKit
 import DriveKitCommonUI
 
-
 class MapViewController: DKUIViewController {
-    
     @IBOutlet var mapView: MKMapView!
     @IBOutlet var adviceButton: UIButton!
     
@@ -27,7 +25,7 @@ class MapViewController: DKUIViewController {
     var authorizedPhoneCallPolylines: [MKPolyline]?
     var speedingPolylines: [MKPolyline]?
 
-    var startAnnotation : MKPointAnnotation? = nil
+    var startAnnotation: MKPointAnnotation? = nil
     var endAnnotation: MKPointAnnotation? = nil
     
     var safetyAnnotations: [MKPointAnnotation]? = nil
@@ -54,10 +52,6 @@ class MapViewController: DKUIViewController {
         self.mapView.delegate = self
         let mapTap = UITapGestureRecognizer(target: self, action: #selector(mapTapped))
         mapView.addGestureRecognizer(mapTap)
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
     }
     
     func traceRoute(mapItem: DKMapItem?, mapTraceType: DKMapTraceType = .unlockScreen) {
@@ -482,6 +476,18 @@ class MapViewController: DKUIViewController {
         if let polyLine = self.polyLine {
             self.mapView.setVisibleMapRect(polyLine.boundingMapRect, edgePadding: self.inset, animated: true)
         }
+    }
+
+    func updateStartAndEndAnnotations() {
+        var annotations: [MKAnnotation] = []
+        if let startAnnotation = self.startAnnotation {
+            annotations.append(startAnnotation)
+        }
+        if let endAnnotation = self.endAnnotation {
+            annotations.append(endAnnotation)
+        }
+        self.mapView.removeAnnotations(annotations)
+        self.mapView.addAnnotations(annotations)
     }
     
     func updateTipsButton() {

--- a/DriveKitDriverDataUI/Trip Detail/ViewControllers/TripDetailVC.swift
+++ b/DriveKitDriverDataUI/Trip Detail/ViewControllers/TripDetailVC.swift
@@ -12,7 +12,6 @@ import DriveKitDriverDataModule
 import DriveKitCommonUI
 
 class TripDetailVC: DKUIViewController {
-    
     @IBOutlet var mapContainer: UIView!
     @IBOutlet var pageContainer: UIView!
     @IBOutlet var actionView: UIView!
@@ -28,7 +27,7 @@ class TripDetailVC: DKUIViewController {
     var mapViewController: MapViewController!
     var mapItemButtons: [UIButton] = []
     
-    private var showAdvice : Bool
+    private var showAdvice: Bool
     
     init(itinId: String, showAdvice: Bool, listConfiguration: TripListConfiguration) {
         self.viewModel = TripDetailViewModel(itinId: itinId, listConfiguration: listConfiguration)
@@ -56,7 +55,7 @@ class TripDetailVC: DKUIViewController {
         self.configureDeleteButton()
     }
     
-    private func configureDeleteButton(){
+    private func configureDeleteButton() {
         if DriveKitDriverDataUI.shared.enableDeleteTrip {
             let image = UIImage(named: "dk_delete_trip", in: Bundle.driverDataUIBundle, compatibleWith: nil)?.resizeImage(25, opaque: false).withRenderingMode(.alwaysTemplate)
             let deleteButton = UIBarButtonItem(image: image , style: .plain, target: self, action: #selector(deleteTrip))
@@ -65,17 +64,17 @@ class TripDetailVC: DKUIViewController {
         }
     }
     
-    @objc private func deleteTrip(){
+    @objc private func deleteTrip() {
         let alert = UIAlertController(title: "", message: "dk_driverdata_confirm_delete_trip".dkDriverDataLocalized(), preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: DKCommonLocalizable.cancel.text(), style: .cancel, handler: nil))
         alert.addAction(UIAlertAction(title: DKCommonLocalizable.ok.text(), style: .default, handler: { action in
             self.showLoader()
-            DriveKitDriverData.shared.deleteTrip(itinId: self.viewModel.itinId, completionHandler: {deleteSuccessful in
+            DriveKitDriverData.shared.deleteTrip(itinId: self.viewModel.itinId, completionHandler: { deleteSuccessful in
                 DispatchQueue.main.async {
                     self.hideLoader()
                     if deleteSuccessful {
                         self.showSuccessDelete()
-                    }else{
+                    } else {
                         self.showErrorDelete()
                     }
                 }
@@ -100,7 +99,6 @@ class TripDetailVC: DKUIViewController {
 }
 
 extension TripDetailVC {
-    
     func updateViewToCurrentMapItem(direction: UIPageViewController.NavigationDirection? = nil) {
         if showAdvice {
             var mapItemsWithAdvices: [DKMapItem] = []
@@ -215,10 +213,10 @@ extension TripDetailVC {
         }
     }
     
-    private func setupShortTrip(){
+    private func setupShortTrip() {
         if let mapItem = self.viewModel.configurableMapItems.first(where: { $0.overrideShortTrip()}) {
             swipableViewControllers.append(mapItem.viewController(trip: self.viewModel.trip!, parentViewController: self, tripDetailViewModel: self.viewModel))
-        } else{
+        } else {
             let shortTripViewModel = ShortTripPageViewModel(trip: self.viewModel.trip!)
             let shortTripVC = ShortTripPageVC(viewModel: shortTripViewModel)
             swipableViewControllers.append(shortTripVC)
@@ -249,7 +247,7 @@ extension TripDetailVC {
         cameraButton.addTarget(self, action: #selector(tapOnCamera(_:)), for: .touchUpInside)
     }
     
-    func setupTipButton(){
+    func setupTipButton() {
         if let trip = viewModel.trip, let advice = viewModel.displayMapItem?.getAdvice(trip: trip) {
             tipButton.layer.borderColor = UIColor.black.cgColor
             tipButton.layer.cornerRadius = tipButton.bounds.size.width / 2
@@ -265,7 +263,7 @@ extension TripDetailVC {
                 showAdvice = false
                 self.clickedAdvices(tipButton)
             }
-        }else{
+        } else {
             tipButton.isHidden = true
         }
     }
@@ -298,7 +296,6 @@ extension TripDetailVC {
 }
 
 extension TripDetailVC: TripDetailDelegate {
-    
     func noRoute() {
         DispatchQueue.main.async {
             self.showNoRouteAlert()
@@ -356,7 +353,7 @@ extension TripDetailVC: TripDetailDelegate {
         self.hideLoader()
     }
     
-    func onEventSelected(event: TripEvent, position: Int){
+    func onEventSelected(event: TripEvent, position: Int) {
         mapViewController.zoomToEvent(event: event)
         if let pos = viewModel.configurableMapItems.firstIndex(of: MapItem.interactiveMap) {
             (self.swipableViewControllers[pos] as! HistoryPageVC).setToPosition(position: position)
@@ -367,10 +364,14 @@ extension TripDetailVC: TripDetailDelegate {
         self.mapViewController.traceRoute(mapItem: self.viewModel.displayMapItem, mapTraceType: mapTrace)
     }
     
-    private func showNoRouteAlert(){
+    private func showNoRouteAlert() {
         let alert = UIAlertController(title: nil, message: "dk_driverdata_trip_detail_get_road_failed".dkDriverDataLocalized(), preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: DKCommonLocalizable.ok.text(), style: .cancel, handler: nil))
         self.present(alert, animated: true, completion: nil)
+    }
+
+    func didUpdateTripCities() {
+        self.mapViewController.updateStartAndEndAnnotations()
     }
 }
 
@@ -398,7 +399,7 @@ extension TripDetailVC: UIPageViewControllerDelegate {
     }
 }
 
-extension TripDetailVC :  UIPageViewControllerDataSource {
+extension TripDetailVC: UIPageViewControllerDataSource {
     func pageViewController(_ pageViewController: UIPageViewController, viewControllerBefore viewController: UIViewController) -> UIViewController? {
         guard let viewControllerIndex = swipableViewControllers.firstIndex(of: viewController), viewControllerIndex > 0 else {
             return nil
@@ -433,4 +434,3 @@ extension TripDetailVC :  UIPageViewControllerDataSource {
         return 0
     }
 }
-

--- a/DriveKitDriverDataUI/Trip Detail/ViewModels/TripDetailViewModel.swift
+++ b/DriveKitDriverDataUI/Trip Detail/ViewModels/TripDetailViewModel.swift
@@ -121,9 +121,9 @@ class TripDetailViewModel: DKTripDetailViewModel {
     private func computeEvents() {
         if let routeSync = self.routeSync, let tripSyncStatus = self.tripSyncStatus {
             if let trip = trip, route != nil {
-                DriveKitDriverData.shared.getMissingCities(trip: trip) { updated in
+                DriveKitDriverData.shared.getMissingCities(trip: trip) { [weak self] updated in
                     if updated {
-                        self.delegate?.didUpdateTripCities()
+                        self?.delegate?.didUpdateTripCities()
                     }
                 }
             }

--- a/DriveKitDriverDataUI/Trip List/Extensions/Trip+DKTripsListItem.swift
+++ b/DriveKitDriverDataUI/Trip List/Extensions/Trip+DKTripsListItem.swift
@@ -9,6 +9,7 @@
 import Foundation
 import UIKit
 import DriveKitCommonUI
+import DriveKitCoreModule
 import DriveKitDBTripAccessModule
 
 extension Trip: DKTripListItem {
@@ -28,10 +29,18 @@ extension Trip: DKTripListItem {
         return self.endDate ?? Date()
     }
     public func getDepartureCity() -> String? {
-        return self.departureCity
+        if let departureCity = self.departureCity, !departureCity.isEmpty && departureCity != DKAddress.unknownValue {
+            return self.departureCity
+        } else {
+            return self.departureAddress
+        }
     }
     public func getArrivalCity() -> String? {
-        return self.arrivalCity
+        if let arrivalCity = self.arrivalCity, !arrivalCity.isEmpty && arrivalCity != DKAddress.unknownValue {
+            return self.arrivalCity
+        } else {
+            return self.arrivalAddress
+        }
     }
 
     public func isScored(tripData: TripData) -> Bool {

--- a/DriveKitDriverDataUI/Trip List/ViewModel/TripListViewModel.swift
+++ b/DriveKitDriverDataUI/Trip List/ViewModel/TripListViewModel.swift
@@ -13,8 +13,8 @@ import DriveKitCommonUI
 import DriveKitCoreModule
 
 class TripListViewModel {
-    private var trips : [DKTripsByDate] = []
-    var filteredTrips : [DKTripsByDate] = []
+    private var trips: [DKTripsByDate] = []
+    var filteredTrips: [DKTripsByDate] = []
     var status: TripSyncStatus = .noError
     private(set) var listConfiguration: TripListConfiguration = .motorized()
     
@@ -124,10 +124,10 @@ class TripListViewModel {
         }
     }
     
-    private func filterTrips(vehicleId : String?) {
+    private func filterTrips(vehicleId: String?) {
         if let vehicleId = vehicleId {
             self.filterTrips {$0.vehicleId == vehicleId}
-        }else{
+        } else {
             let motorizedModes = TripListConfiguration.motorized().transportationModes()
             self.filterTrips { motorizedModes.contains(TransportationMode(rawValue: Int(($0 as Trip).transportationMode)) ?? TransportationMode.unknown) }
         }
@@ -158,7 +158,7 @@ class TripListViewModel {
         }
     }
     
-    private func filterTrips(_ isIncluded : (Trip) -> Bool) {
+    private func filterTrips(_ isIncluded: (Trip) -> Bool) {
         self.filteredTrips = []
         for tripsByDate in self.trips {
             if let trips = tripsByDate.trips as? [Trip] {
@@ -190,11 +190,11 @@ class TripListViewModel {
     }
 }
 
-protocol TripsDelegate : AnyObject {
+protocol TripsDelegate: AnyObject {
     func onTripsAvailable()
 }
 
-class AllTripFilterItem : DKFilterItem {
+class AllTripFilterItem: DKFilterItem {
     func getImage() -> UIImage? {
         return UIImage(named: "dk_my_trips", in: Bundle.driverDataUIBundle, compatibleWith: nil)
     }
@@ -208,7 +208,7 @@ class AllTripFilterItem : DKFilterItem {
     }
 }
 
-class AllAlternativeMode : DKFilterItem {
+class AllAlternativeMode: DKFilterItem {
     func getImage() -> UIImage? {
         return UIImage(named: "dk_transportation_all", in: Bundle.driverDataUIBundle, compatibleWith: nil)
     }


### PR DESCRIPTION
@ag-drivequant Pour tester, il faut que tu accèdes localement aux pods internes (avec les améliorations ReverseGeocoder, comme sur develop par exemple).

Il y a 2 cas :
- Un trajet n'a pas de ville de départ ou d'arrivée mais il a une adresse → dans la liste des trajets, au lieu d'afficher "" ou "N/A" comme ville de départ ou d'arrivée de ce trajet, on doit afficher l'adresse
- Quand un trajet n'avais pas d'adresse de départ ou d'arrivée, un ReverseGeocoder était effectué à l'affichage des détails du trajet mais lorsqu'on tapait sur le pin de départ ou d'arrivée du trajet, on n'avait pas l'adresse dans l'annotation. Il fallait taper sur le bouton de geoloc dans la barre en haut à droite pour que l'adresse apparaisse au tap.

Pour faire les tests, tu peux prendre un trajet et modifier ces villes avec le service `/drivekit/driver/trips/{itinId}/cities` sur StopLight, par exemple :
```
{
  "departureCity": "",
  "arrivalCity": "",
  "departureAddress": "",
  "arrivalAddress": ""
}
```