### PR TITLE
Update duration format

### DIFF
--- a/DriveKitCommonUI/Utils/DKDataFormatter.swift
+++ b/DriveKitCommonUI/Utils/DKDataFormatter.swift
@@ -32,7 +32,6 @@ extension Array where Element == FormatType {
 }
 
 public extension Double {
-
     func getMeterDistanceInKmFormat(appendingUnit appendUnit: Bool = true) -> [FormatType] {
         return (self / 1000.0).getKilometerDistanceFormat(appendingUnit: appendUnit)
     }
@@ -180,12 +179,8 @@ public extension Double {
                     if nbHour > 0 {
                         formattingTypes = [
                             .value(String(nbDay)),
-                            .separator(),
                             .unit(DKCommonLocalizable.unitDay.text()),
-                            .separator(),
                             .value(String(nbHour)),
-                            .separator(),
-                            .unit(DKCommonLocalizable.unitHour.text())
                         ]
                     } else {
                         formattingTypes = [
@@ -199,9 +194,7 @@ public extension Double {
                         let minuteString = String(format: "%02d", nbMinute)
                         formattingTypes = [
                             .value(String(nbHour)),
-                            .separator(),
                             .unit(DKCommonLocalizable.unitHour.text()),
-                            .separator(),
                             .value(minuteString)
                         ]
                     } else {
@@ -218,9 +211,7 @@ public extension Double {
                     let secondString = String(format: "%02d", nbSecond)
                     formattingTypes = [
                         .value(String(nbMinute - 1)),
-                        .separator(),
                         .unit(DKCommonLocalizable.unitMinute.text()),
-                        .separator(),
                         .value(secondString)
                     ]
                 } else {


### PR DESCRIPTION
Modifications à effectuer :
- `< 1min : “xx s” : le plus long “59 s”`
- `< 10 min : “xminxx” : le plus long “9min59”`
- `Si sec = 0 alors on n’affiche que les minutes`
- `< 1h : “xx min” : le plus long “59 min”`
- `>= 1h : “xhxx” (ou “x h” si min = 0)`
- `>=1j : “xjxx” (ou “x j” si h = 0)`
- `Si min = 0 alors on n’affiche que les heures`


Pour tester, j'ai ajouté une fonction :
```
    private func format(days: Int = 0, hours: Int = 0, minutes: Int = 0, seconds: Int = 0, maxUnit: DurationUnit = .day) {
        let durationInSeconds = Double(seconds + 60 * minutes + 3600 * hours + 86400 * days)
        print("days = \(days) - hours = \(hours) - minutes = \(minutes) - seconds = \(seconds) - maxUnit = \(maxUnit)  -->  \(durationInSeconds.formatSecondDuration(maxUnit: maxUnit))")
    }
```
Et j'ai appelé :
```
        format(days: 1, hours: 1, minutes: 1, seconds: 1, maxUnit: .day)
        format(days: 1, hours: 1, minutes: 1, seconds: 1, maxUnit: .hour)
        format(days: 1, hours: 1, minutes: 1, seconds: 1, maxUnit: .minute)
        format(days: 1, hours: 1, minutes: 1, seconds: 1, maxUnit: .second)
        format(days: 1, maxUnit: .day)
        format(hours: 1, maxUnit: .hour)
        format(minutes: 1, maxUnit: .minute)
        format(seconds: 1, maxUnit: .second)
```