### PR TITLE
Feature/423 timeline merge roadcontext and emptyroadcontext

### DIFF
--- a/DriveKitApp.xcodeproj/project.pbxproj
+++ b/DriveKitApp.xcodeproj/project.pbxproj
@@ -366,7 +366,7 @@
 		63F8B2B728F960BA0084B53A /* PeriodSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F8B2B628F960BA0084B53A /* PeriodSelectorView.swift */; };
 		63F8B2B928F960CA0084B53A /* PeriodSelectorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F8B2B828F960CA0084B53A /* PeriodSelectorViewModel.swift */; };
 		63F8B2BB28F960E20084B53A /* PeriodSelectorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F8B2BA28F960E20084B53A /* PeriodSelectorDelegate.swift */; };
-		63F8B2BF28F961440084B53A /* RoadContextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F8B2BE28F961440084B53A /* RoadContextView.swift */; };
+		63F8B2BF28F961440084B53A /* RoadContextDataView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F8B2BE28F961440084B53A /* RoadContextDataView.swift */; };
 		63F8B2C128F961570084B53A /* RoadContextViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F8B2C028F961570084B53A /* RoadContextViewModel.swift */; };
 		63F8B2C328F9617C0084B53A /* TimelineViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F8B2C228F9617C0084B53A /* TimelineViewController.swift */; };
 		63F8B2C528F961960084B53A /* TimelineViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F8B2C428F961960084B53A /* TimelineViewModel.swift */; };
@@ -505,7 +505,7 @@
 		67CFE9A725F645EA004D0AE1 /* SpeedingPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67CFE9A625F645EA004D0AE1 /* SpeedingPageViewModel.swift */; };
 		67CFE9F925FA1385004D0AE1 /* SpeedingPageItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67CFE9F825FA1385004D0AE1 /* SpeedingPageItemView.swift */; };
 		67CFEA0025FA16EC004D0AE1 /* SpeedingPageItemView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 67CFE9FF25FA16EC004D0AE1 /* SpeedingPageItemView.xib */; };
-		67D6CD862908276F0055632B /* RoadContextView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 67D6CD852908276F0055632B /* RoadContextView.xib */; };
+		67D6CD862908276F0055632B /* RoadContextDataView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 67D6CD852908276F0055632B /* RoadContextDataView.xib */; };
 		67D6CD8929090B750055632B /* RoadContextItemCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D6CD8729090B750055632B /* RoadContextItemCell.swift */; };
 		67D6CD8A29090B750055632B /* RoadContextItemCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 67D6CD8829090B750055632B /* RoadContextItemCell.xib */; };
 		67D6CD8C290912640055632B /* EmptyRoadContextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D6CD8B290912640055632B /* EmptyRoadContextView.swift */; };
@@ -614,6 +614,7 @@
 		A3D51F51241BA3AE006DACE2 /* VehiclesListCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = A3D51F4D241BA3AE006DACE2 /* VehiclesListCell.xib */; };
 		AD2690683829D301D9573CEC /* Pods_DriveKitChallengeUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 158BFF3EE484B6293C97E890 /* Pods_DriveKitChallengeUI.framework */; };
 		C2ECBA09D9742158769AE627 /* Pods_DriveKitPermissionsUtilsUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A3A98094797ED33BAF53826 /* Pods_DriveKitPermissionsUtilsUI.framework */; };
+		E3B8309D294B1DCE00E31848 /* RoadContextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3B8309C294B1DCE00E31848 /* RoadContextView.swift */; };
 		FA5F8336F7F9D6E9CBACE91B /* Pods_DriveKitDriverAchievementUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 36173251B2A47392720E8B05 /* Pods_DriveKitDriverAchievementUI.framework */; };
 		FE2C04BD97A78F4B22CD7008 /* Pods_DriveKitDriverDataUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 55652B494DACA2423EDB5A8E /* Pods_DriveKitDriverDataUI.framework */; };
 /* End PBXBuildFile section */
@@ -1162,7 +1163,7 @@
 		63F8B2B628F960BA0084B53A /* PeriodSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeriodSelectorView.swift; sourceTree = "<group>"; };
 		63F8B2B828F960CA0084B53A /* PeriodSelectorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeriodSelectorViewModel.swift; sourceTree = "<group>"; };
 		63F8B2BA28F960E20084B53A /* PeriodSelectorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeriodSelectorDelegate.swift; sourceTree = "<group>"; };
-		63F8B2BE28F961440084B53A /* RoadContextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoadContextView.swift; sourceTree = "<group>"; };
+		63F8B2BE28F961440084B53A /* RoadContextDataView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoadContextDataView.swift; sourceTree = "<group>"; };
 		63F8B2C028F961570084B53A /* RoadContextViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoadContextViewModel.swift; sourceTree = "<group>"; };
 		63F8B2C228F9617C0084B53A /* TimelineViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineViewController.swift; sourceTree = "<group>"; };
 		63F8B2C428F961960084B53A /* TimelineViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineViewModel.swift; sourceTree = "<group>"; };
@@ -1301,7 +1302,7 @@
 		67CFE9A625F645EA004D0AE1 /* SpeedingPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedingPageViewModel.swift; sourceTree = "<group>"; };
 		67CFE9F825FA1385004D0AE1 /* SpeedingPageItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedingPageItemView.swift; sourceTree = "<group>"; };
 		67CFE9FF25FA16EC004D0AE1 /* SpeedingPageItemView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SpeedingPageItemView.xib; sourceTree = "<group>"; };
-		67D6CD852908276F0055632B /* RoadContextView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RoadContextView.xib; sourceTree = "<group>"; };
+		67D6CD852908276F0055632B /* RoadContextDataView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RoadContextDataView.xib; sourceTree = "<group>"; };
 		67D6CD8729090B750055632B /* RoadContextItemCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoadContextItemCell.swift; sourceTree = "<group>"; };
 		67D6CD8829090B750055632B /* RoadContextItemCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RoadContextItemCell.xib; sourceTree = "<group>"; };
 		67D6CD8B290912640055632B /* EmptyRoadContextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyRoadContextView.swift; sourceTree = "<group>"; };
@@ -1433,6 +1434,7 @@
 		A3D51F4D241BA3AE006DACE2 /* VehiclesListCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = VehiclesListCell.xib; sourceTree = "<group>"; };
 		C6CF2F88D8CEC4FD0F65BD58 /* Pods-DriveKitChallengeUI.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DriveKitChallengeUI.debug.xcconfig"; path = "Target Support Files/Pods-DriveKitChallengeUI/Pods-DriveKitChallengeUI.debug.xcconfig"; sourceTree = "<group>"; };
 		DCBF31C151237FEA8EDE3CF0 /* Pods-DriveKitDriverDataUI.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DriveKitDriverDataUI.release.xcconfig"; path = "Target Support Files/Pods-DriveKitDriverDataUI/Pods-DriveKitDriverDataUI.release.xcconfig"; sourceTree = "<group>"; };
+		E3B8309C294B1DCE00E31848 /* RoadContextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoadContextView.swift; sourceTree = "<group>"; };
 		FA713DC763C119AEF200C7B2 /* Pods-DriveKitDriverDataTimelineUI.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DriveKitDriverDataTimelineUI.debug.xcconfig"; path = "Target Support Files/Pods-DriveKitDriverDataTimelineUI/Pods-DriveKitDriverDataTimelineUI.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -2500,9 +2502,10 @@
 		63F8B29F28F95EF70084B53A /* RoadContext */ = {
 			isa = PBXGroup;
 			children = (
-				63F8B2BE28F961440084B53A /* RoadContextView.swift */,
+				E3B8309C294B1DCE00E31848 /* RoadContextView.swift */,
 				63F8B2C028F961570084B53A /* RoadContextViewModel.swift */,
-				67D6CD852908276F0055632B /* RoadContextView.xib */,
+				63F8B2BE28F961440084B53A /* RoadContextDataView.swift */,
+				67D6CD852908276F0055632B /* RoadContextDataView.xib */,
 				67D6CD8729090B750055632B /* RoadContextItemCell.swift */,
 				67D6CD8829090B750055632B /* RoadContextItemCell.xib */,
 				67D6CD8B290912640055632B /* EmptyRoadContextView.swift */,
@@ -3813,7 +3816,7 @@
 				63F8B29E28F95E3F0084B53A /* Timeline.xcassets in Resources */,
 				63F8B2D028F9B27B0084B53A /* DriverDataTimelineLocalizable.strings in Resources */,
 				67D6CD8A29090B750055632B /* RoadContextItemCell.xib in Resources */,
-				67D6CD862908276F0055632B /* RoadContextView.xib in Resources */,
+				67D6CD862908276F0055632B /* RoadContextDataView.xib in Resources */,
 				639D184B29008919008293B8 /* PeriodSelectorView.xib in Resources */,
 				67D6CD90291013760055632B /* DateSelectorView.xib in Resources */,
 				63F8B2DF28FDB0A20084B53A /* ScoreSelectionTypeView.xib in Resources */,
@@ -4391,7 +4394,8 @@
 				63F8B2B528F960900084B53A /* TimelineGraphDelegate.swift in Sources */,
 				63454B8F29067C6000A9B10F /* GraphViewModel.swift in Sources */,
 				63454B9F2907DC8D00A9B10F /* TimelineDateExtension.swift in Sources */,
-				63F8B2BF28F961440084B53A /* RoadContextView.swift in Sources */,
+				E3B8309D294B1DCE00E31848 /* RoadContextView.swift in Sources */,
+				63F8B2BF28F961440084B53A /* RoadContextDataView.swift in Sources */,
 				63F8B2C128F961570084B53A /* RoadContextViewModel.swift in Sources */,
 				63F8B2C528F961960084B53A /* TimelineViewModel.swift in Sources */,
 				674B3B2329196CE800C62895 /* GraphConstants.swift in Sources */,

--- a/DriveKitApp.xcodeproj/project.pbxproj
+++ b/DriveKitApp.xcodeproj/project.pbxproj
@@ -615,6 +615,7 @@
 		AD2690683829D301D9573CEC /* Pods_DriveKitChallengeUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 158BFF3EE484B6293C97E890 /* Pods_DriveKitChallengeUI.framework */; };
 		C2ECBA09D9742158769AE627 /* Pods_DriveKitPermissionsUtilsUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A3A98094797ED33BAF53826 /* Pods_DriveKitPermissionsUtilsUI.framework */; };
 		E3B8309D294B1DCE00E31848 /* RoadContextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3B8309C294B1DCE00E31848 /* RoadContextView.swift */; };
+		E3B8309F294B5D3F00E31848 /* DKTimelineExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3B8309E294B5D3F00E31848 /* DKTimelineExtension.swift */; };
 		FA5F8336F7F9D6E9CBACE91B /* Pods_DriveKitDriverAchievementUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 36173251B2A47392720E8B05 /* Pods_DriveKitDriverAchievementUI.framework */; };
 		FE2C04BD97A78F4B22CD7008 /* Pods_DriveKitDriverDataUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 55652B494DACA2423EDB5A8E /* Pods_DriveKitDriverDataUI.framework */; };
 /* End PBXBuildFile section */
@@ -1435,6 +1436,7 @@
 		C6CF2F88D8CEC4FD0F65BD58 /* Pods-DriveKitChallengeUI.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DriveKitChallengeUI.debug.xcconfig"; path = "Target Support Files/Pods-DriveKitChallengeUI/Pods-DriveKitChallengeUI.debug.xcconfig"; sourceTree = "<group>"; };
 		DCBF31C151237FEA8EDE3CF0 /* Pods-DriveKitDriverDataUI.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DriveKitDriverDataUI.release.xcconfig"; path = "Target Support Files/Pods-DriveKitDriverDataUI/Pods-DriveKitDriverDataUI.release.xcconfig"; sourceTree = "<group>"; };
 		E3B8309C294B1DCE00E31848 /* RoadContextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoadContextView.swift; sourceTree = "<group>"; };
+		E3B8309E294B5D3F00E31848 /* DKTimelineExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DKTimelineExtension.swift; sourceTree = "<group>"; };
 		FA713DC763C119AEF200C7B2 /* Pods-DriveKitDriverDataTimelineUI.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DriveKitDriverDataTimelineUI.debug.xcconfig"; path = "Target Support Files/Pods-DriveKitDriverDataTimelineUI/Pods-DriveKitDriverDataTimelineUI.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -2495,6 +2497,7 @@
 				63F8B29D28F95E3F0084B53A /* Timeline.xcassets */,
 				63F8B29C28F95C2C0084B53A /* Info.plist */,
 				63F8B29128F958B90084B53A /* DriveKitDriverDataTimelineUI.h */,
+				E3B8309E294B5D3F00E31848 /* DKTimelineExtension.swift */,
 			);
 			path = DriveKitDriverDataTimelineUI;
 			sourceTree = "<group>";
@@ -4410,6 +4413,7 @@
 				638E683E291A3E2000A5CC81 /* TimelineDetailViewModel.swift in Sources */,
 				63F8B2B728F960BA0084B53A /* PeriodSelectorView.swift in Sources */,
 				67D6CD8C290912640055632B /* EmptyRoadContextView.swift in Sources */,
+				E3B8309F294B5D3F00E31848 /* DKTimelineExtension.swift in Sources */,
 				63F8B2D928FD4B500084B53A /* TimelineViewModelDelegate.swift in Sources */,
 				63454BA129081DD500A9B10F /* Graph.swift in Sources */,
 				63454B9629068FD000A9B10F /* TimelineScoreItemType.swift in Sources */,

--- a/DriveKitDriverDataTimelineUI/Components/RoadContext/EmptyRoadContextView.swift
+++ b/DriveKitDriverDataTimelineUI/Components/RoadContext/EmptyRoadContextView.swift
@@ -12,45 +12,22 @@ import DriveKitCommonUI
 class EmptyRoadContextView: UIView {
     @IBOutlet private weak var titleLabel: UILabel!
     @IBOutlet private weak var descriptionLabel: UILabel!
-    var type: RoadContextType = .emptyData {
-        didSet {
-            update()
-        }
-    }
 
     override func awakeFromNib() {
         super.awakeFromNib()
         setupView()
     }
+    
+    func configure(withTitle title: String, description: String) {
+        self.titleLabel.text = title
+        self.descriptionLabel.text = description
+    }
 
     private func setupView() {
         self.titleLabel.font = DKStyles.headLine2.style.applyTo(font: .primary)
         self.descriptionLabel.font = DKStyles.smallText.style.applyTo(font: .primary)
-        update()
-    }
-
-    private func update() {
-        let titleKey: String
-        let descriptionKey: String
-        switch self.type {
-            case .data:
-                preconditionFailure("We should not display EmptyRoadContextView when we have data")
-            case .emptyData:
-                titleKey = "dk_timeline_road_context_title_empty_data"
-                descriptionKey = "dk_timeline_road_context_description_empty_data"
-            case .noData:
-                titleKey = "dk_timeline_road_context_no_context_title"
-                descriptionKey = "dk_timeline_road_context_no_context_description"
-            case .noDataSafety:
-                titleKey = "dk_timeline_road_context_title_no_data"
-                descriptionKey = "dk_timeline_road_context_description_no_data_safety"
-            case .noDataEcodriving:
-                titleKey = "dk_timeline_road_context_title_no_data"
-                descriptionKey = "dk_timeline_road_context_description_no_data_ecodriving"
-        }
-        self.titleLabel.text = titleKey.dkDriverDataTimelineLocalized()
-        self.descriptionLabel.text = descriptionKey.dkDriverDataTimelineLocalized()
         self.titleLabel.textColor = DKUIColors.primaryColor.color
         self.descriptionLabel.textColor = DKUIColors.complementaryFontColor.color
+
     }
 }

--- a/DriveKitDriverDataTimelineUI/Components/RoadContext/EmptyRoadContextView.swift
+++ b/DriveKitDriverDataTimelineUI/Components/RoadContext/EmptyRoadContextView.swift
@@ -12,7 +12,7 @@ import DriveKitCommonUI
 class EmptyRoadContextView: UIView {
     @IBOutlet private weak var titleLabel: UILabel!
     @IBOutlet private weak var descriptionLabel: UILabel!
-    var type: EmptyRoadContextType = .emptyData {
+    var type: RoadContextType = .emptyData {
         didSet {
             update()
         }
@@ -51,11 +51,4 @@ class EmptyRoadContextView: UIView {
         self.titleLabel.textColor = DKUIColors.primaryColor.color
         self.descriptionLabel.textColor = DKUIColors.complementaryFontColor.color
     }
-}
-
-enum EmptyRoadContextType {
-    case emptyData
-    case noData
-    case noDataSafety
-    case noDataEcodriving
 }

--- a/DriveKitDriverDataTimelineUI/Components/RoadContext/EmptyRoadContextView.swift
+++ b/DriveKitDriverDataTimelineUI/Components/RoadContext/EmptyRoadContextView.swift
@@ -33,6 +33,8 @@ class EmptyRoadContextView: UIView {
         let titleKey: String
         let descriptionKey: String
         switch self.type {
+            case .data:
+                preconditionFailure("We should not display EmptyRoadContextView when we have data")
             case .emptyData:
                 titleKey = "dk_timeline_road_context_title_empty_data"
                 descriptionKey = "dk_timeline_road_context_description_empty_data"

--- a/DriveKitDriverDataTimelineUI/Components/RoadContext/RoadContextDataView.swift
+++ b/DriveKitDriverDataTimelineUI/Components/RoadContext/RoadContextDataView.swift
@@ -1,0 +1,138 @@
+//
+//  RoadContextDataView.swift
+//  DriveKitDriverDataTimelineUI
+//
+//  Created by David Bauduin on 14/10/2022.
+//  Copyright © 2022 DriveQuant. All rights reserved.
+//
+
+import UIKit
+import DriveKitCommonUI
+import DriveKitDBTripAccessModule
+
+class RoadContextDataView: UIView {
+    static let collectionViewCellHeight: CGFloat = 26.0
+    @IBOutlet private weak var roadContextBarView: RoadContextBarView!
+    @IBOutlet private weak var titleLabel: UILabel!
+    @IBOutlet private weak var itemsCollectionView: UICollectionView!
+    @IBOutlet private weak var collectionViewHeightConstraint: NSLayoutConstraint!
+    private var viewModel: RoadContextViewModel?
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        setupView()
+    }
+
+    func setupView() {
+        self.titleLabel.font = DKStyles.smallText.style.applyTo(font: .primary)
+        self.itemsCollectionView.register(UINib(nibName: "RoadContextItemCell", bundle: .driverDataTimelineUIBundle), forCellWithReuseIdentifier: "RoadContextItemCell")
+        self.refreshView()
+    }
+
+    func refreshView() {
+        if let viewModel = viewModel {
+            self.titleLabel.text = viewModel.title
+            self.roadContextBarView.configure(viewModel: viewModel)
+        }
+        self.collectionViewHeightConstraint.constant =
+         RoadContextDataView.collectionViewCellHeight *
+        CGFloat(Int(ceil(Double(viewModel?.getActiveContextNumber() ?? 1) / 2.0)))
+        self.itemsCollectionView.reloadData()
+    }
+
+    func configure(viewModel: RoadContextViewModel) {
+        self.viewModel = viewModel
+        self.refreshView()
+    }
+}
+
+extension RoadContextDataView: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        guard let viewModel = viewModel else { return 0 }
+        return viewModel.getActiveContextNumber()
+    }
+
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell: UICollectionViewCell = collectionView.dequeueReusableCell(withReuseIdentifier: "RoadContextItemCell", for: indexPath)
+        if let itemCell = cell as? RoadContextItemCell,
+           let items = viewModel?.itemsToDraw,
+           items.count > indexPath.row {
+            let context = items[indexPath.row].context
+            itemCell.update(title: RoadContextViewModel.getRoadContextTitle(context), color: RoadContextViewModel.getRoadContextColor(context))
+        }
+        return cell
+    }
+}
+extension RoadContextDataView: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return CGSize(width: collectionView.bounds.width/2, height: RoadContextDataView.collectionViewCellHeight)
+    }
+}
+extension RoadContextDataView: RoadContextViewModelDelegate {
+    func roadContextViewModelDidUpdate() {
+        setupView()
+    }
+}
+
+class RoadContextBarView: UIView {
+    static private let radius: Double = 8
+    static private let margin: Double = 0
+    private var viewModel: RoadContextViewModel?
+
+    override func draw(_ rect: CGRect) {
+        guard let itemsToDraw = viewModel?.itemsToDraw, itemsToDraw.count > 0 else {
+            return
+        }
+        var drawnPercent: Double = 0
+        for i in 0..<itemsToDraw.count {
+            let roundedStart: Bool = (i == 0)
+            let roundedEnd: Bool = (i == itemsToDraw.count - 1)
+            let startX = drawnPercent*(rect.width - 2*RoadContextBarView.margin) + RoadContextBarView.margin
+            let itemRect = CGRect(x: startX, y: RoadContextBarView.margin, width: (rect.width - 2*RoadContextBarView.margin)*itemsToDraw[i].percent, height: rect.height - 2*RoadContextBarView.margin)
+            self.drawPartView(itemRect, color: RoadContextViewModel.getRoadContextColor(itemsToDraw[i].context).cgColor, roundedStart: roundedStart, roundedEnd: roundedEnd)
+            drawnPercent = drawnPercent + itemsToDraw[i].percent
+        }
+
+        let maskLayer = CAShapeLayer()
+        let path = CGMutablePath()
+        path.addPath(UIBezierPath(roundedRect: rect, cornerRadius: RoadContextBarView.radius).cgPath)
+        maskLayer.path = path
+        self.layer.mask = maskLayer;
+    }
+
+    private func drawPartView(_ rect: CGRect, color: CGColor, roundedStart: Bool = false, roundedEnd: Bool = false) {
+        let bezierPath = UIBezierPath()
+        let startPoint = rect.origin
+        let endPoint = CGPoint(x: rect.origin.x + rect.width, y: rect.origin.y + rect.height)
+        if roundedStart {
+            bezierPath.addArc(withCenter: CGPoint(x: startPoint.x + RoadContextBarView.radius, y: startPoint.y + RoadContextBarView.radius), radius: RoadContextBarView.radius, startAngle: .pi, endAngle: .pi*3/2, clockwise: true)
+        } else {
+            bezierPath.move(to: startPoint)
+        }
+        if roundedEnd {
+            bezierPath.addLine(to: CGPoint(x: endPoint.x - RoadContextBarView.radius, y: startPoint.y))
+            bezierPath.addArc(withCenter: CGPoint(x: endPoint.x - RoadContextBarView.radius, y: startPoint.y + RoadContextBarView.radius), radius: RoadContextBarView.radius, startAngle: .pi*3/2, endAngle: .pi*2, clockwise: true)
+            bezierPath.addLine(to: CGPoint(x: endPoint.x, y: endPoint.y - RoadContextBarView.radius))
+            bezierPath.addArc(withCenter: CGPoint(x: endPoint.x - RoadContextBarView.radius, y: endPoint.y - RoadContextBarView.radius), radius: RoadContextBarView.radius, startAngle: 0, endAngle: .pi/2, clockwise: true)
+        } else {
+            bezierPath.addLine(to: CGPoint(x: endPoint.x, y: startPoint.y))
+            bezierPath.addLine(to: CGPoint(x: endPoint.x, y: endPoint.y))
+        }
+        if roundedStart {
+            bezierPath.addLine(to: CGPoint(x: startPoint.x + RoadContextBarView.radius, y: endPoint.y))
+            bezierPath.addLine(to: CGPoint(x: startPoint.x + RoadContextBarView.radius, y: endPoint.y))
+            bezierPath.addArc(withCenter: CGPoint(x: startPoint.x + RoadContextBarView.radius, y: endPoint.y - RoadContextBarView.radius), radius: RoadContextBarView.radius, startAngle: .pi/2, endAngle: .pi, clockwise: true)
+            bezierPath.addLine(to: CGPoint(x: startPoint.x, y: startPoint.y - RoadContextBarView.radius))
+        } else {
+            bezierPath.addLine(to: CGPoint(x: startPoint.x, y: endPoint.y))
+            bezierPath.addLine(to: CGPoint(x: startPoint.x, y: startPoint.y))
+        }
+        UIGraphicsGetCurrentContext()?.setFillColor(color)
+        bezierPath.fill()
+    }
+
+    func configure(viewModel: RoadContextViewModel) {
+        self.viewModel = viewModel
+        self.setNeedsDisplay()
+    }
+}

--- a/DriveKitDriverDataTimelineUI/Components/RoadContext/RoadContextDataView.xib
+++ b/DriveKitDriverDataTimelineUI/Components/RoadContext/RoadContextDataView.xib
@@ -11,7 +11,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="RoadContextView" customModule="DriveKitDriverDataTimelineUI" customModuleProvider="target">
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="RoadContextDataView" customModule="DriveKitDriverDataTimelineUI" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="390" height="169"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>

--- a/DriveKitDriverDataTimelineUI/Components/RoadContext/RoadContextView.swift
+++ b/DriveKitDriverDataTimelineUI/Components/RoadContext/RoadContextView.swift
@@ -2,137 +2,22 @@
 //  RoadContextView.swift
 //  DriveKitDriverDataTimelineUI
 //
-//  Created by David Bauduin on 14/10/2022.
+//  Created by Frédéric Ruaudel on 15/12/2022.
 //  Copyright © 2022 DriveQuant. All rights reserved.
 //
 
 import UIKit
-import DriveKitCommonUI
-import DriveKitDBTripAccessModule
 
 class RoadContextView: UIView {
-    static let collectionViewCellHeight: CGFloat = 26.0
-    @IBOutlet private weak var roadContextBarView: RoadContextBarView!
-    @IBOutlet private weak var titleLabel: UILabel!
-    @IBOutlet private weak var itemsCollectionView: UICollectionView!
-    @IBOutlet private weak var collectionViewHeightConstraint: NSLayoutConstraint!
     private var viewModel: RoadContextViewModel?
-
-    override func awakeFromNib() {
-        super.awakeFromNib()
-        setupView()
-    }
-
-    func setupView() {
-        self.titleLabel.font = DKStyles.smallText.style.applyTo(font: .primary)
-        self.itemsCollectionView.register(UINib(nibName: "RoadContextItemCell", bundle: .driverDataTimelineUIBundle), forCellWithReuseIdentifier: "RoadContextItemCell")
-        self.refreshView()
-    }
-
-    func refreshView() {
-        if let viewModel = viewModel {
-            self.titleLabel.text = viewModel.title
-            self.roadContextBarView.configure(viewModel: viewModel)
-        }
-        self.collectionViewHeightConstraint.constant =
-         RoadContextView.collectionViewCellHeight *
-        CGFloat(Int(ceil(Double(viewModel?.getActiveContextNumber() ?? 1) / 2.0)))
-        self.itemsCollectionView.reloadData()
-    }
 
     func configure(viewModel: RoadContextViewModel) {
         self.viewModel = viewModel
-        self.refreshView()
     }
 }
 
-extension RoadContextView: UICollectionViewDataSource {
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        guard let viewModel = viewModel else { return 0 }
-        return viewModel.getActiveContextNumber()
-    }
-
-    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell: UICollectionViewCell = collectionView.dequeueReusableCell(withReuseIdentifier: "RoadContextItemCell", for: indexPath)
-        if let itemCell = cell as? RoadContextItemCell,
-           let items = viewModel?.itemsToDraw,
-           items.count > indexPath.row {
-            let context = items[indexPath.row].context
-            itemCell.update(title: RoadContextViewModel.getRoadContextTitle(context), color: RoadContextViewModel.getRoadContextColor(context))
-        }
-        return cell
-    }
-}
-extension RoadContextView: UICollectionViewDelegateFlowLayout {
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return CGSize(width: collectionView.bounds.width/2, height: RoadContextView.collectionViewCellHeight)
-    }
-}
 extension RoadContextView: RoadContextViewModelDelegate {
     func roadContextViewModelDidUpdate() {
-        setupView()
-    }
-}
-
-class RoadContextBarView: UIView {
-    static private let radius: Double = 8
-    static private let margin: Double = 0
-    private var viewModel: RoadContextViewModel?
-
-    override func draw(_ rect: CGRect) {
-        guard let itemsToDraw = viewModel?.itemsToDraw, itemsToDraw.count > 0 else {
-            return
-        }
-        var drawnPercent: Double = 0
-        for i in 0..<itemsToDraw.count {
-            let roundedStart: Bool = (i == 0)
-            let roundedEnd: Bool = (i == itemsToDraw.count - 1)
-            let startX = drawnPercent*(rect.width - 2*RoadContextBarView.margin) + RoadContextBarView.margin
-            let itemRect = CGRect(x: startX, y: RoadContextBarView.margin, width: (rect.width - 2*RoadContextBarView.margin)*itemsToDraw[i].percent, height: rect.height - 2*RoadContextBarView.margin)
-            self.drawPartView(itemRect, color: RoadContextViewModel.getRoadContextColor(itemsToDraw[i].context).cgColor, roundedStart: roundedStart, roundedEnd: roundedEnd)
-            drawnPercent = drawnPercent + itemsToDraw[i].percent
-        }
-
-        let maskLayer = CAShapeLayer()
-        let path = CGMutablePath()
-        path.addPath(UIBezierPath(roundedRect: rect, cornerRadius: RoadContextBarView.radius).cgPath)
-        maskLayer.path = path
-        self.layer.mask = maskLayer;
-    }
-
-    private func drawPartView(_ rect: CGRect, color: CGColor, roundedStart: Bool = false, roundedEnd: Bool = false) {
-        let bezierPath = UIBezierPath()
-        let startPoint = rect.origin
-        let endPoint = CGPoint(x: rect.origin.x + rect.width, y: rect.origin.y + rect.height)
-        if roundedStart {
-            bezierPath.addArc(withCenter: CGPoint(x: startPoint.x + RoadContextBarView.radius, y: startPoint.y + RoadContextBarView.radius), radius: RoadContextBarView.radius, startAngle: .pi, endAngle: .pi*3/2, clockwise: true)
-        } else {
-            bezierPath.move(to: startPoint)
-        }
-        if roundedEnd {
-            bezierPath.addLine(to: CGPoint(x: endPoint.x - RoadContextBarView.radius, y: startPoint.y))
-            bezierPath.addArc(withCenter: CGPoint(x: endPoint.x - RoadContextBarView.radius, y: startPoint.y + RoadContextBarView.radius), radius: RoadContextBarView.radius, startAngle: .pi*3/2, endAngle: .pi*2, clockwise: true)
-            bezierPath.addLine(to: CGPoint(x: endPoint.x, y: endPoint.y - RoadContextBarView.radius))
-            bezierPath.addArc(withCenter: CGPoint(x: endPoint.x - RoadContextBarView.radius, y: endPoint.y - RoadContextBarView.radius), radius: RoadContextBarView.radius, startAngle: 0, endAngle: .pi/2, clockwise: true)
-        } else {
-            bezierPath.addLine(to: CGPoint(x: endPoint.x, y: startPoint.y))
-            bezierPath.addLine(to: CGPoint(x: endPoint.x, y: endPoint.y))
-        }
-        if roundedStart {
-            bezierPath.addLine(to: CGPoint(x: startPoint.x + RoadContextBarView.radius, y: endPoint.y))
-            bezierPath.addLine(to: CGPoint(x: startPoint.x + RoadContextBarView.radius, y: endPoint.y))
-            bezierPath.addArc(withCenter: CGPoint(x: startPoint.x + RoadContextBarView.radius, y: endPoint.y - RoadContextBarView.radius), radius: RoadContextBarView.radius, startAngle: .pi/2, endAngle: .pi, clockwise: true)
-            bezierPath.addLine(to: CGPoint(x: startPoint.x, y: startPoint.y - RoadContextBarView.radius))
-        } else {
-            bezierPath.addLine(to: CGPoint(x: startPoint.x, y: endPoint.y))
-            bezierPath.addLine(to: CGPoint(x: startPoint.x, y: startPoint.y))
-        }
-        UIGraphicsGetCurrentContext()?.setFillColor(color)
-        bezierPath.fill()
-    }
-
-    func configure(viewModel: RoadContextViewModel) {
-        self.viewModel = viewModel
-        self.setNeedsDisplay()
+        #warning("TBD")
     }
 }

--- a/DriveKitDriverDataTimelineUI/Components/RoadContext/RoadContextView.swift
+++ b/DriveKitDriverDataTimelineUI/Components/RoadContext/RoadContextView.swift
@@ -31,7 +31,7 @@ class RoadContextView: UIView {
 
     func refreshView() {
         if let viewModel = viewModel {
-            self.titleLabel.text = viewModel.getTitle()
+            self.titleLabel.text = viewModel.title
             self.roadContextBarView.configure(viewModel: viewModel)
         }
         self.collectionViewHeightConstraint.constant =

--- a/DriveKitDriverDataTimelineUI/Components/RoadContext/RoadContextView.swift
+++ b/DriveKitDriverDataTimelineUI/Components/RoadContext/RoadContextView.swift
@@ -9,15 +9,58 @@
 import UIKit
 
 class RoadContextView: UIView {
-    private var viewModel: RoadContextViewModel?
-
+    private var viewModel: RoadContextViewModel!
+    private var roadContextDataView: RoadContextDataView!
+    private var emptyRoadContextView: EmptyRoadContextView!
+    
+    override init(frame: CGRect) {
+        guard let roadContextDataView = Bundle.driverDataTimelineUIBundle?.loadNibNamed(
+            "RoadContextDataView",
+            owner: nil,
+            options: nil
+        )?.first as? RoadContextDataView else {
+            preconditionFailure("Can't find bundle or nib for RoadContextDataView")
+        }
+        self.roadContextDataView = roadContextDataView
+        
+        guard let emptyRoadContextView = Bundle.driverDataTimelineUIBundle?.loadNibNamed(
+            "EmptyRoadContextView",
+            owner: nil,
+            options: nil
+        )?.first as? EmptyRoadContextView else {
+            preconditionFailure("Can't find bundle or nib for EmptyRoadContextView")
+        }
+        self.emptyRoadContextView = emptyRoadContextView
+        
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     func configure(viewModel: RoadContextViewModel) {
         self.viewModel = viewModel
+        self.updateUI()
+    }
+    
+    private func updateUI() {
+        self.removeSubviews()
+        if self.viewModel.hasData {
+            self.roadContextDataView.configure(viewModel: self.viewModel)
+            self.embedSubview(roadContextDataView)
+        } else {
+            emptyRoadContextView.configure(
+                withTitle: viewModel.title,
+                description: viewModel.emptyDataDescription
+            )
+            self.embedSubview(emptyRoadContextView)
+        }
     }
 }
 
 extension RoadContextView: RoadContextViewModelDelegate {
     func roadContextViewModelDidUpdate() {
-        #warning("TBD")
+        self.updateUI()
     }
 }

--- a/DriveKitDriverDataTimelineUI/Components/RoadContext/RoadContextViewModel.swift
+++ b/DriveKitDriverDataTimelineUI/Components/RoadContext/RoadContextViewModel.swift
@@ -9,6 +9,13 @@
 import UIKit
 import DriveKitDBTripAccessModule
 
+enum RoadContextType {
+    case emptyData
+    case noData
+    case noDataSafety
+    case noDataEcodriving
+}
+
 class RoadContextViewModel {
     private var distanceByContext: [TimelineRoadContext: Double] = [:]
     private var totalDistanceForDisplayedContexts: Double = 0

--- a/DriveKitDriverDataTimelineUI/Components/RoadContext/RoadContextViewModel.swift
+++ b/DriveKitDriverDataTimelineUI/Components/RoadContext/RoadContextViewModel.swift
@@ -10,6 +10,10 @@ import UIKit
 import DriveKitDBTripAccessModule
 
 enum RoadContextType {
+    case data(
+        distanceByContext: [TimelineRoadContext: Double],
+        totalDistanceForAllContexts: Double
+    )
     case emptyData
     case noData
     case noDataSafety

--- a/DriveKitDriverDataTimelineUI/Components/RoadContext/RoadContextViewModel.swift
+++ b/DriveKitDriverDataTimelineUI/Components/RoadContext/RoadContextViewModel.swift
@@ -57,6 +57,9 @@ class RoadContextViewModel {
     private static let expresswaysColor = UIColor(hex: 0x8FB7C2)
     weak var delegate: RoadContextViewModelDelegate?
 
+    var hasData: Bool {
+        roadContextType.hasData
+    }
     
     var itemsToDraw: [(context: TimelineRoadContext, percent: Double)] = []
 

--- a/DriveKitDriverDataTimelineUI/Components/RoadContext/RoadContextViewModel.swift
+++ b/DriveKitDriverDataTimelineUI/Components/RoadContext/RoadContextViewModel.swift
@@ -80,6 +80,22 @@ class RoadContextViewModel {
         }
     }
     
+    var emptyDataDescription: String {
+        switch roadContextType {
+            case .data:
+                assertionFailure("We should not display emptyDataDescription when we have data")
+                return ""
+            case .emptyData:
+                return "dk_timeline_road_context_description_empty_data".dkDriverDataTimelineLocalized()
+            case .noData:
+                return "dk_timeline_road_context_no_context_description".dkDriverDataTimelineLocalized()
+            case .noDataSafety:
+                return "dk_timeline_road_context_description_no_data_safety".dkDriverDataTimelineLocalized()
+            case .noDataEcodriving:
+                return "dk_timeline_road_context_description_no_data_ecodriving".dkDriverDataTimelineLocalized()
+        }
+    }
+    
     func configure(with roadContextType: RoadContextType) {
         self.roadContextType = roadContextType
         self.totalDistanceForDisplayedContexts = roadContextType.distanceByContext.reduce(

--- a/DriveKitDriverDataTimelineUI/Components/RoadContext/RoadContextViewModel.swift
+++ b/DriveKitDriverDataTimelineUI/Components/RoadContext/RoadContextViewModel.swift
@@ -18,6 +18,33 @@ enum RoadContextType {
     case noData
     case noDataSafety
     case noDataEcodriving
+    
+    var hasData: Bool {
+        switch self {
+        case .data:
+            return true
+        case .noData, .emptyData, .noDataSafety, .noDataEcodriving:
+            return false
+        }
+    }
+    
+    var distanceByContext: [TimelineRoadContext: Double] {
+        switch self {
+        case let .data(distanceByContext, _):
+            return distanceByContext
+        case .noData, .emptyData, .noDataSafety, .noDataEcodriving:
+            return [:]
+        }
+    }
+    
+    var totalDistanceForAllContexts: Double {
+        switch self {
+        case let .data(_, totalDistanceForAllContexts):
+            return totalDistanceForAllContexts
+        case .noData, .emptyData, .noDataSafety, .noDataEcodriving:
+            return 0
+        }
+    }
 }
 
 class RoadContextViewModel {

--- a/DriveKitDriverDataTimelineUI/Components/RoadContext/RoadContextViewModel.swift
+++ b/DriveKitDriverDataTimelineUI/Components/RoadContext/RoadContextViewModel.swift
@@ -96,8 +96,43 @@ class RoadContextViewModel {
         }
     }
     
-    func configure(with roadContextType: RoadContextType) {
-        self.roadContextType = roadContextType
+    func configure(
+        with selectedScore: DKTimelineScoreType,
+        timeline: DKTimeline?,
+        selectedIndex: Int? = nil
+    ) {
+        if let timeline, let selectedIndex, timeline.hasData {
+            var distanceByContext: [TimelineRoadContext: Double] = [:]
+            var totalDistanceForAllContexts: Double = 0
+            
+            distanceByContext = timeline.distanceByRoadContext(
+                selectedScore: selectedScore,
+                selectedIndex: selectedIndex
+            )
+            totalDistanceForAllContexts = timeline.totalDistanceForAllContexts(
+                selectedScore: selectedScore,
+                selectedIndex: selectedIndex
+            )
+            
+            if distanceByContext.isEmpty {
+                switch selectedScore {
+                case .distraction, .speeding:
+                    roadContextType = .noData
+                case .safety:
+                    roadContextType = .noDataSafety
+                case .ecoDriving:
+                    roadContextType = .noDataEcodriving
+                }
+            } else {
+                roadContextType = .data(
+                    distanceByContext: distanceByContext,
+                    totalDistanceForAllContexts: totalDistanceForAllContexts
+                )
+            }
+        } else {
+            roadContextType = .emptyData
+        }
+        
         self.totalDistanceForDisplayedContexts = roadContextType.distanceByContext.reduce(
             into: 0.0
         ) { distance, element in

--- a/DriveKitDriverDataTimelineUI/Components/RoadContext/RoadContextViewModel.swift
+++ b/DriveKitDriverDataTimelineUI/Components/RoadContext/RoadContextViewModel.swift
@@ -60,7 +60,7 @@ class RoadContextViewModel {
     
     var itemsToDraw: [(context: TimelineRoadContext, percent: Double)] = []
 
-    func getTitle() -> String {
+    var title: String {
         switch self.roadContextType {
             case let .data(_, totalDistanceForAllContexts):
             return String(

--- a/DriveKitDriverDataTimelineUI/DKTimelineExtension.swift
+++ b/DriveKitDriverDataTimelineUI/DKTimelineExtension.swift
@@ -1,0 +1,55 @@
+//
+//  DKTimelineExtension.swift
+//  DriveKitDriverDataTimelineUI
+//
+//  Created by Frédéric Ruaudel on 13/12/2022.
+//  Copyright © 2022 DriveQuant. All rights reserved.
+//
+import Foundation
+import DriveKitDBTripAccessModule
+
+extension DKTimeline {
+    /// Compute distance by road contexts from the timeline
+    func distanceByRoadContext(
+        selectedScore: DKTimelineScoreType,
+        selectedIndex: Int
+    ) -> [TimelineRoadContext: Double] {
+        var distanceByContext: [TimelineRoadContext: Double] = [:]
+        if self.hasValidTripScored(for: selectedScore, selectedIndex: selectedIndex) {
+            for roadContext in self.roadContexts {
+                if let timelineRoadContext = TimelineRoadContext(roadContext: roadContext.type) {
+                    let distance = roadContext.distance[selectedIndex]
+                    if distance > 0 {
+                        distanceByContext[timelineRoadContext] = distance
+                    }
+                }
+            }
+        }
+        
+        return distanceByContext
+    }
+
+    func totalDistanceForAllContexts(
+        selectedScore: DKTimelineScoreType,
+        selectedIndex: Int
+    ) -> Double {
+        var totalDistanceForAllContexts: Double = 0
+        if self.hasValidTripScored(for: selectedScore, selectedIndex: selectedIndex) {
+            totalDistanceForAllContexts = self.allContext.distance[selectedIndex]
+        }
+        
+        return totalDistanceForAllContexts
+    }
+    
+    private func hasValidTripScored(
+        for selectedScore: DKTimelineScoreType,
+        selectedIndex: Int
+    ) -> Bool {
+        // Distraction and Speeding can have score for short trip which
+        // are not counted in `numberTripScored`. `numberTripScored` only
+        // count fully scored trip for all four scores
+        return selectedScore == .distraction
+            || selectedScore == .speeding
+            || self.allContext.numberTripScored[selectedIndex] > 0
+    }
+}

--- a/DriveKitDriverDataTimelineUI/DKTimelineExtension.swift
+++ b/DriveKitDriverDataTimelineUI/DKTimelineExtension.swift
@@ -9,6 +9,11 @@ import Foundation
 import DriveKitDBTripAccessModule
 
 extension DKTimeline {
+    
+    var hasData: Bool {
+        self.allContext.numberTripTotal.isEmpty == false
+    }
+    
     /// Compute distance by road contexts from the timeline
     func distanceByRoadContext(
         selectedScore: DKTimelineScoreType,

--- a/DriveKitDriverDataTimelineUI/Localizable/da.lproj/DriverDataTimelineLocalizable.strings
+++ b/DriveKitDriverDataTimelineUI/Localizable/da.lproj/DriverDataTimelineLocalizable.strings
@@ -30,6 +30,8 @@
 "dk_timeline_road_context_title"="Vejforhold (%@)";
 "dk_timeline_road_context_title_empty_data"="Du har endnu ikke nogen data";
 "dk_timeline_road_context_title_no_data"="Ingen data til visning";
+"dk_timeline_road_context_no_context_title" = "Ingen sammenhæng";
+"dk_timeline_road_context_no_context_description" = "Rejserne for de valgte datoer har ingen sammenhæng.";
 "dk_timeline_safety_score"="Sikkerhedsscore: %@";
 "dk_timeline_speeding_score"="Fartgrænsescore: %@";
 "dk_timeline_title"="Tidslinje";

--- a/DriveKitDriverDataTimelineUI/Localizable/de.lproj/DriverDataTimelineLocalizable.strings
+++ b/DriveKitDriverDataTimelineUI/Localizable/de.lproj/DriverDataTimelineLocalizable.strings
@@ -30,6 +30,8 @@
 "dk_timeline_road_context_title"="Straßenkontext (%@)";
 "dk_timeline_road_context_title_empty_data"="Sie haben noch keine Daten";
 "dk_timeline_road_context_title_no_data"="Keine Daten anzeigen";
+"dk_timeline_road_context_no_context_title" = "Es gibt keinen Kontext";
+"dk_timeline_road_context_no_context_description" = "Die Fahrten für die ausgewählten Daten haben keinen Kontext.";
 "dk_timeline_safety_score"="Sicherheitspunkte: %@";
 "dk_timeline_speeding_score"="Geschwindigkeitswert: %@";
 "dk_timeline_title"="Zeitleiste";

--- a/DriveKitDriverDataTimelineUI/Localizable/en.lproj/DriverDataTimelineLocalizable.strings
+++ b/DriveKitDriverDataTimelineUI/Localizable/en.lproj/DriverDataTimelineLocalizable.strings
@@ -30,6 +30,8 @@
 "dk_timeline_road_context_title"="Driving context (%@)";
 "dk_timeline_road_context_title_empty_data"="You don\'t have any data yet";
 "dk_timeline_road_context_title_no_data"="No data to display";
+"dk_timeline_road_context_no_context_title" = "No context";
+"dk_timeline_road_context_no_context_description" = "The trips for the selected dates have no context.";
 "dk_timeline_safety_score"="Safety score: %@";
 "dk_timeline_speeding_score"="Speeding score: %@";
 "dk_timeline_title"="Timeline";

--- a/DriveKitDriverDataTimelineUI/Localizable/es.lproj/DriverDataTimelineLocalizable.strings
+++ b/DriveKitDriverDataTimelineUI/Localizable/es.lproj/DriverDataTimelineLocalizable.strings
@@ -30,6 +30,8 @@
 "dk_timeline_road_context_title"="Contexto de carretera (%@)";
 "dk_timeline_road_context_title_empty_data"="Todavía no tiene datos";
 "dk_timeline_road_context_title_no_data"="No hay datos para visualizar";
+"dk_timeline_road_context_no_context_title" = "Sin contexto";
+"dk_timeline_road_context_no_context_description" = "Los viajes para las fechas seleccionadas no tienen contexto.";
 "dk_timeline_safety_score"="Puntuación de seguridad: %@";
 "dk_timeline_speeding_score"="Puntaje de velocidad: %@";
 "dk_timeline_title"="Cronología";

--- a/DriveKitDriverDataTimelineUI/Localizable/fr.lproj/DriverDataTimelineLocalizable.strings
+++ b/DriveKitDriverDataTimelineUI/Localizable/fr.lproj/DriverDataTimelineLocalizable.strings
@@ -30,6 +30,8 @@
 "dk_timeline_road_context_title"="Contexte routier (%@)";
 "dk_timeline_road_context_title_empty_data"="Vous n\'avez pas encore de données";
 "dk_timeline_road_context_title_no_data"="Pas de données à afficher";
+"dk_timeline_road_context_no_context_title" = "Aucun contexte";
+"dk_timeline_road_context_no_context_description" = "Les trajets pour les dates sélectionnées n'ont pas de contexte.";
 "dk_timeline_safety_score"="Score de sécurité : %@";
 "dk_timeline_speeding_score"="Score de vitesse : %@";
 "dk_timeline_title"="Timeline";

--- a/DriveKitDriverDataTimelineUI/Localizable/it.lproj/DriverDataTimelineLocalizable.strings
+++ b/DriveKitDriverDataTimelineUI/Localizable/it.lproj/DriverDataTimelineLocalizable.strings
@@ -30,6 +30,8 @@
 "dk_timeline_road_context_title"="Contesto stradale (%@)";
 "dk_timeline_road_context_title_empty_data"="Non si dispone ancora di dati";
 "dk_timeline_road_context_title_no_data"="Nessun dato da visualizzare";
+"dk_timeline_road_context_no_context_title" = "Nessun contesto";
+"dk_timeline_road_context_no_context_description" = "I viaggi per le date selezionate non sono contestualizzati.";
 "dk_timeline_safety_score"="Punteggio di sicurezza: %@";
 "dk_timeline_speeding_score"="Punteggio di velocità: %@";
 "dk_timeline_title"="Timeline";

--- a/DriveKitDriverDataTimelineUI/Timeline/TimelineViewController.swift
+++ b/DriveKitDriverDataTimelineUI/Timeline/TimelineViewController.swift
@@ -18,8 +18,8 @@ class TimelineViewController: DKUIViewController {
     @IBOutlet private weak var timelineGraphViewContainer: UIView!
     private let viewModel: TimelineViewModel
     private var selectedScoreSelectionTypeView: ScoreSelectionTypeView? = nil
-    private let roadContextview = Bundle.driverDataTimelineUIBundle?.loadNibNamed("RoadContextView", owner: nil, options: nil)?.first as? RoadContextView
-    private let emptyRoadContextView = Bundle.driverDataTimelineUIBundle?.loadNibNamed("EmptyRoadContextView", owner: nil, options: nil)?.first as? EmptyRoadContextView
+    private let roadContextView = RoadContextView()
+//    private let emptyRoadContextView = Bundle.driverDataTimelineUIBundle?.loadNibNamed("EmptyRoadContextView", owner: nil, options: nil)?.first as? EmptyRoadContextView
     private let cornerRadius: CGFloat = 8
 
     init(viewModel: TimelineViewModel) {
@@ -149,35 +149,9 @@ class TimelineViewController: DKUIViewController {
     private func setupRoadContext() {
         self.roadContextContainer.layer.cornerRadius = self.cornerRadius
         self.roadContextContainer.clipsToBounds = true
-        if let roadContextview = self.roadContextview {
-            self.viewModel.roadContextViewModel.delegate = roadContextview
-            roadContextview.configure(viewModel: self.viewModel.roadContextViewModel)
-        }
-        self.refreshRoadContextContainer()
-    }
-
-    private func refreshRoadContextContainer() {
-        guard let roadContextview = self.roadContextview, let emptyRoadContextView = self.emptyRoadContextView else {
-            return
-        }
-        self.roadContextContainer.removeSubviews()
-        if self.viewModel.roadContextViewModel.getActiveContextNumber() > 0 {
-            self.roadContextContainer.embedSubview(roadContextview)
-        } else {
-            if !self.viewModel.hasData {
-                emptyRoadContextView.type = .emptyData
-            } else {
-                switch self.viewModel.selectedScore {
-                    case .distraction, .speeding:
-                        emptyRoadContextView.type = .noData
-                    case .safety:
-                        emptyRoadContextView.type = .noDataSafety
-                    case .ecoDriving:
-                        emptyRoadContextView.type = .noDataEcodriving
-                }
-            }
-            self.roadContextContainer.embedSubview(emptyRoadContextView)
-        }
+        self.viewModel.roadContextViewModel.delegate = roadContextView
+        roadContextView.configure(viewModel: self.viewModel.roadContextViewModel)
+        self.roadContextContainer.embedSubview(roadContextView)
     }
 }
 
@@ -188,11 +162,5 @@ extension TimelineViewController: TimelineViewModelDelegate {
 
     func didUpdateTimeline() {
         hideRefreshControl()
-        self.refreshRoadContextContainer()
     }
-
-    func needToBeRefreshed() {
-        self.refreshRoadContextContainer()
-    }
-
 }

--- a/DriveKitDriverDataTimelineUI/Timeline/TimelineViewModel.swift
+++ b/DriveKitDriverDataTimelineUI/Timeline/TimelineViewModel.swift
@@ -24,13 +24,6 @@ class TimelineViewModel {
             update()
         }
     }
-    var hasData: Bool {
-        if let timelineSource = getTimelineSource() {
-            return !timelineSource.allContext.numberTripTotal.isEmpty
-        } else {
-            return false
-        }
-    }
     private var weekTimeline: DKTimeline?
     private var monthTimeline: DKTimeline?
     private var currentPeriod: DKTimelinePeriod
@@ -142,7 +135,6 @@ class TimelineViewModel {
         } else {
             configureWithNoData()
         }
-        self.delegate?.needToBeRefreshed()
     }
 
     private func configureWithNoData() {

--- a/DriveKitDriverDataTimelineUI/Timeline/TimelineViewModel.swift
+++ b/DriveKitDriverDataTimelineUI/Timeline/TimelineViewModel.swift
@@ -131,7 +131,11 @@ class TimelineViewModel {
                 self.dateSelectorViewModel.configure(dates: dates, period: self.currentPeriod, selectedIndex: selectedDateIndex)
                 self.periodSelectorViewModel.configure(selectedPeriod: self.currentPeriod)
                 self.timelineGraphViewModel.configure(timeline: cleanedTimeline, timelineSelectedIndex: selectedDateIndex, graphItem: .score(self.selectedScore), period: self.currentPeriod)
-                updateRoadContextViewModel(timeline: cleanedTimeline, selectedIndex: selectedDateIndex)
+                self.roadContextViewModel.configure(
+                    with: selectedScore,
+                    timeline: cleanedTimeline,
+                    selectedIndex: selectedDateIndex
+                )
             } else {
                 configureWithNoData()
             }
@@ -154,30 +158,11 @@ class TimelineViewModel {
         if let startDate {
             self.dateSelectorViewModel.configure(dates: [startDate], period: self.currentPeriod, selectedIndex: 0)
             self.timelineGraphViewModel.showEmptyGraph(graphItem: .score(self.selectedScore), period: self.currentPeriod)
-            updateRoadContextViewModel(timeline: getTimelineSource(), selectedIndex: nil)
-        }
-    }
-
-    private func updateRoadContextViewModel(timeline: DKTimeline?, selectedIndex: Int?) {
-        let totalDistanceForAllContexts: Double
-        var distanceByContext: [TimelineRoadContext: Double] = [:]
-        if let timeline, let selectedIndex, self.selectedScore == .distraction || self.selectedScore == .speeding || timeline.allContext.numberTripScored[selectedIndex] > 0 {
-            totalDistanceForAllContexts = timeline.allContext.distance[selectedIndex]
-            for roadContext in timeline.roadContexts {
-                if let timelineRoadContext = TimelineRoadContext(roadContext: roadContext.type) {
-                    let distance = roadContext.distance[selectedIndex]
-                    distanceByContext[timelineRoadContext] = distance
-                }
-            }
-        } else {
-            totalDistanceForAllContexts = 0
-        }
-        self.roadContextViewModel.configure(
-            with: .data(
-                distanceByContext: distanceByContext,
-                totalDistanceForAllContexts: totalDistanceForAllContexts
+            roadContextViewModel.configure(
+                with: selectedScore,
+                timeline: getTimelineSource()
             )
-        )
+        }
     }
 
     private func getTimelineSource() -> DKTimeline? {

--- a/DriveKitDriverDataTimelineUI/Timeline/TimelineViewModel.swift
+++ b/DriveKitDriverDataTimelineUI/Timeline/TimelineViewModel.swift
@@ -172,7 +172,12 @@ class TimelineViewModel {
         } else {
             totalDistanceForAllContexts = 0
         }
-        self.roadContextViewModel.configure(distanceByContext: distanceByContext, totalDistanceForAllContexts: totalDistanceForAllContexts)
+        self.roadContextViewModel.configure(
+            with: .data(
+                distanceByContext: distanceByContext,
+                totalDistanceForAllContexts: totalDistanceForAllContexts
+            )
+        )
     }
 
     private func getTimelineSource() -> DKTimeline? {

--- a/DriveKitDriverDataTimelineUI/Timeline/TimelineViewModelDelegate.swift
+++ b/DriveKitDriverDataTimelineUI/Timeline/TimelineViewModelDelegate.swift
@@ -11,5 +11,4 @@ import Foundation
 protocol TimelineViewModelDelegate: AnyObject {
     func willUpdateTimeline()
     func didUpdateTimeline()
-    func needToBeRefreshed()
 }


### PR DESCRIPTION
Cette MR inclus la fusion de la `RoadContextView` et de l'`EmptyRoadContextView`. La logique qui était dispersé entre le `TimelineViewController` et le `TimelineViewModel` a été rassemblé dans le `RoadContextViewModel` et l'ancienne `RoadContextView` a été renommé `RoadContextDataView`.