### PR TITLE
PermissionUtilsUI: do not show screen for a permission that is already given

### DIFF
--- a/DriveKitPermissionsUtilsUI/DriveKitPermissionsUtilsUI.swift
+++ b/DriveKitPermissionsUtilsUI/DriveKitPermissionsUtilsUI.swift
@@ -44,23 +44,10 @@ import DriveKitCommonUI
         // Nothing to do currently.
     }
 
-    // swiftlint:disable:next cyclomatic_complexity
     public func showPermissionViews(_ permissionViews: [DKPermissionView], parentViewController: UIViewController, manageNavigation: Bool = true, completionHandler: @escaping () -> Void) {
         // Keep only needed permission views.
         let neededPermissionViews = permissionViews.filter { permissionView in
-            let permissionType = permissionView.getPermissionType()
-            switch permissionType {
-                case .activity:
-                    return !DKDiagnosisHelper.shared.isActivityValid() && DKDiagnosisHelper.shared.getPermissionStatus(permissionType) != .phoneRestricted // For activity permission, allow `.phoneRestricted` status because of a system bug (if the user allows access to Motion & Fitness in global settings, on coming back to the app, the status of this permission is still "restricted" instead of something else).
-                case .location:
-                    return !DKDiagnosisHelper.shared.isLocationValid()
-                case .bluetooth:
-                    return false
-                case .notifications:
-                    return DKDiagnosisHelper.shared.getPermissionStatus(.notifications) != .valid && !DKPermissionView.notifications.shouldIgnore()
-                @unknown default:
-                    return false
-            }
+            permissionView.isDisplayAllowed
         }
         if neededPermissionViews.isEmpty {
             completionHandler()

--- a/DriveKitPermissionsUtilsUI/Permissions/DKPermissionView.swift
+++ b/DriveKitPermissionsUtilsUI/Permissions/DKPermissionView.swift
@@ -61,4 +61,21 @@ import DriveKitCoreModule
             DriveKitCoreUserDefaults.setPrimitiveType(key: key, value: true)
         }
     }
+
+    var isDisplayAllowed: Bool {
+        let permissionType = self.getPermissionType()
+        switch permissionType {
+            case .activity:
+                // swiftlint:disable:next line_length
+                return !DKDiagnosisHelper.shared.isActivityValid() && DKDiagnosisHelper.shared.getPermissionStatus(permissionType) != .phoneRestricted // For activity permission, allow `.phoneRestricted` status because of a system bug (if the user allows access to Motion & Fitness in global settings, on coming back to the app, the status of this permission is still "restricted" instead of something else).
+            case .location:
+                return !DKDiagnosisHelper.shared.isLocationValid()
+            case .bluetooth:
+                return false
+            case .notifications:
+                return DKDiagnosisHelper.shared.getPermissionStatus(.notifications) != .valid && !DKPermissionView.notifications.shouldIgnore()
+            @unknown default:
+                return false
+        }
+    }
 }

--- a/DriveKitPermissionsUtilsUI/Permissions/PermissionViewController.swift
+++ b/DriveKitPermissionsUtilsUI/Permissions/PermissionViewController.swift
@@ -47,9 +47,9 @@ class PermissionViewController: DKUIViewController {
 extension PermissionViewController: PermissionView {
 
     func next() {
-        // Remove current permission view from the list.
-        if !self.permissionViews.isEmpty {
-            self.permissionViews.removeFirst()
+        // remove already accepted permissions
+        self.permissionViews = self.permissionViews.filter { permissionView in
+            permissionView.isDisplayAllowed
         }
 
         if let nextPermissionView = self.permissionViews.first {


### PR DESCRIPTION
PermissionUtilsUI: do not show screen for a permission that is already given